### PR TITLE
Specify PerfectCRUD.Expression

### DIFF
--- a/Sources/MariaDB/MySQLCRUD.swift
+++ b/Sources/MariaDB/MySQLCRUD.swift
@@ -191,7 +191,7 @@ class MySQLGenDelegate: SQLGenDelegate {
 		return "() VALUES ()"
 	}
 	
-	func getBinding(for expr: Expression) throws -> String {
+	func getBinding(for expr: PerfectCRUD.Expression) throws -> String {
 		bindings.append(("?", expr))
 		return "?"
 	}


### PR DESCRIPTION
Foundation.Expression was introduced in iOS 18.0 / macOS 15.0 and causes ambiguity in MySQLCRUD.swift